### PR TITLE
Mods for 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the instance itself and any clients that join. Similarly the node-to-node
 communication port (9300) is only available to other units in the elasticsearch
 service. You can change this explicitly with:
 
-    juju set elasticsearch firewall_enabled=false
+    juju config elasticsearch firewall_enabled=false
 
 See the separate HACKING.md for information about deploying this charm
 from a local repository.
@@ -67,6 +67,25 @@ with the other units in the cluster (via the peer-relation-joined
 hook), after which ElasticSearch handles the rest.
 
 # Configuration
+
+## Elasticsearch 5.x
+This charm fully supports Elasticsearch 5.x!
+To deploy ES 5.x add the following to your config prior
+to deploying the charm.
+
+Example config for Elasticsearch 5.x
+```yaml
+# es-config.yaml
+
+apt-repository: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+apt-key-url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+gpg-key-id: "D88E42B4"
+
+```
+Then reference the config when deploying this charm.
+```bash
+juju deploy elasticsearch --config es-config.yaml
+```
 
 ## Downloading ElasticSearch
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,8 @@ description: |
   Read more at http://www.elasticsearch.org
 tags:
   - misc
+series:
+  - trusty
 subordinate: false
 peers:
   peer:

--- a/tasks/install-elasticsearch.yml
+++ b/tasks/install-elasticsearch.yml
@@ -3,7 +3,11 @@
     - install
     - upgrade-charm
     - config-changed
+{% if '5' in apt_repository %}
+  apt_key: url={{ apt_key_url }} state=present id={{gpg_key_id}} validate_certs=no
+{% else %}
   apt_key: url={{ apt_key_url }} state=present id={{gpg_key_id}}
+{% endif %}
   when: apt_key_url != ""
 
 - name: Add apt archive.
@@ -16,13 +20,22 @@
     state: present
   when: apt_repository != ""
 
+- name: Add java apt archive.
+  tags:
+    - install
+    - upgrade-charm
+    - config-changed
+  apt_repository:
+    repo: "ppa:openjdk-r/ppa"
+    state: present
+
 - name: Install dependent packages.
   apt: pkg={{ item }} state=latest update_cache=yes
   tags:
     - install
     - upgrade-charm
   with_items:
-    - openjdk-7-jre-headless
+    - openjdk-8-jre-headless
     - ufw
 
 - name: Check for local elasticsearch.deb in payload.

--- a/tasks/install-elasticsearch.yml
+++ b/tasks/install-elasticsearch.yml
@@ -3,11 +3,7 @@
     - install
     - upgrade-charm
     - config-changed
-{% if '5' in apt_repository %}
   apt_key: url={{ apt_key_url }} state=present id={{gpg_key_id}} validate_certs=no
-{% else %}
-  apt_key: url={{ apt_key_url }} state=present id={{gpg_key_id}}
-{% endif %}
   when: apt_key_url != ""
 
 - name: Add apt archive.

--- a/templates/elasticsearch.yml
+++ b/templates/elasticsearch.yml
@@ -4,10 +4,16 @@
 cluster.name: {{ cluster_name }}
 http.port: 9200
 network.host: ["_site_", "_local_"]
+{% if not '5' in apt_repository %}
 discovery.zen.ping.multicast.enabled: false
+{% endif %}
+{% if relations.peer is defined and relations.peer|length > 0 %}
 discovery.zen.ping.unicast.hosts:
 {% for reln in relations.peer %}
   - {{ reln['private-address'] }}
 {% endfor %}
+{% endif %}
+{% if not '5' in apt_repository %}
 # workaround for Kibana4 Export Everything bug https://github.com/elastic/kibana/issues/5524
 index.max_result_window: 2147483647
+{% endif %}

--- a/tests/01-single-to-scale-test-es-five.py
+++ b/tests/01-single-to-scale-test-es-five.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python3
+
+import amulet
+import unittest
+import requests
+import json
+
+
+ES_FIVE = {'cluster-name': 'unique-name',
+           'gpg-key-id': 'D88E42B4',
+           'apt-repository': \
+               'deb https://artifacts.elastic.co/packages/5.x/apt stable main',
+           'apt-key-url': 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'}
+
+
+class TestElasticsearchFiveSingle(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.deployment = amulet.Deployment(series='trusty')
+        self.deployment.add('elasticsearch')
+        self.deployment.configure('elasticsearch', ES_FIVE)
+
+        try:
+            self.deployment.setup(timeout=1200)
+            self.deployment.sentry.wait()
+        except amulet.helpers.TimeoutError:
+            amulet.raise_status(
+                amulet.SKIP, msg="Environment wasn't setup in time")
+
+
+    def test_health(self):
+        ''' Test the health of the node upon first deployment
+            by getting the cluster health, then inserting data and
+            validating cluster health'''
+        health = self.get_cluster_health()
+        assert health['status'] in ('green', 'yellow')
+
+        # Create a test index.
+        curl_command = """
+        curl -XPUT 'http://localhost:9200/test/tweet/1' -d '{
+            "user" : "me",
+            "message" : "testing"
+        }'
+        """
+        response = self.curl_on_unit(curl_command)
+        health = self.get_index_health('test')
+        assert health['status'] in ('green', 'yellow')
+
+    def test_config(self):
+        ''' Validate our configuration of the cluster name made it to the
+            application configuration'''
+        health = self.get_cluster_health()
+        cluster_name = health['cluster_name']
+        assert cluster_name == 'unique-name'
+
+    def test_scale(self):
+        ''' Validate scaling the elasticsearch cluster yields a healthy
+            response from the API, and all units are participating '''
+        self.deployment.add_unit('elasticsearch', units=2)
+        self.deployment.setup(timeout=1200)
+        self.deployment.sentry.wait()
+        health = self.get_cluster_health(wait_for_nodes=3)
+        index_health = self.get_index_health('test')
+        print(health['number_of_nodes'])
+        assert health['number_of_nodes'] == 3
+        assert index_health['status'] in ('green', 'yellow')
+
+    def curl_on_unit(self, curl_command, unit_number=0):
+        unit = "elasticsearch"
+        response = self.deployment.sentry[unit][unit_number].run(curl_command)
+        if response[1] != 0:
+            msg = (
+                "Elastic search didn't respond to the command \n"
+                "'{curl_command}' as expected.\n"
+                "Return code: {return_code}\n"
+                "Result: {result}".format(
+                    curl_command=curl_command,
+                    return_code=response[1],
+                    result=response[0])
+            )
+            amulet.raise_status(amulet.FAIL, msg=msg)
+
+        return json.loads(response[0])
+
+    def get_cluster_health(self, unit_number=0, wait_for_nodes=0,
+                           timeout=180):
+        curl_command = "curl http://localhost:9200"
+        curl_command = curl_command + "/_cluster/health?timeout={}s".format(
+            timeout)
+        if wait_for_nodes > 0:
+            curl_command = curl_command + "&wait_for_nodes={}".format(
+                wait_for_nodes)
+
+        return self.curl_on_unit(curl_command, unit_number=unit_number)
+
+    def get_index_health(self, index_name, unit_number=0):
+        curl_command = "curl http://localhost:9200"
+        curl_command = curl_command + "/_cluster/health/" + index_name
+
+        return self.curl_on_unit(curl_command)
+
+
+def check_response(response, expected_code=200):
+    if response.status_code != expected_code:
+        msg = (
+            "Elastic search did not respond as expected. \n"
+            "Expected status code: %{expected_code} \n"
+            "Status code: %{status_code} \n"
+            "Response text: %{response_text}".format(
+                expected_code=expected_code,
+                status_code=response.status_code,
+                response_text=response.text))
+
+        amulet.raise_status(amulet.FAIL, msg=msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Conditionals were added to the elasticsearch.yaml template
to facilitate deprecated configs in 5.x that are needed in > 5.x,
and for configs that cannot exist with no value in 5.x that could
pre 5.x.

* Turn off verify certs for 5.x.

* Modified install-elasticsearch.yml to facilitate not verifying certs when adding the apt key.

* Add single deploy test for ES 5.x.

* Update readme

* Add series to metadata.yaml